### PR TITLE
fix: convert Cursor Rules to correct MDC format

### DIFF
--- a/.cursor/rules/cli.mdc
+++ b/.cursor/rules/cli.mdc
@@ -1,8 +1,7 @@
 ---
-title: "CLI Development Guidelines"
 description: "Cobra and CLI-specific development standards for crawld"
-type: "Auto Attached"
-patterns: ["cmd/**/*.go", "**/*_cmd.go", "**/*command*.go"]
+globs: ["cmd/**/*.go", "**/*_cmd.go", "**/*command*.go"]
+alwaysApply: false
 ---
 
 # CLI Development Guidelines

--- a/.cursor/rules/crawler.mdc
+++ b/.cursor/rules/crawler.mdc
@@ -1,8 +1,7 @@
 ---
-title: "Web Crawler Implementation Guidelines"
-description: "HTTP client, HTML parsing, and crawling logic standards"
-type: "Auto Attached"
-patterns: ["internal/crawler/**/*.go", "**/*crawler*.go", "**/*http*.go"]
+description: "Web crawler implementation guidelines with HTTP client configuration and HTML parsing"
+globs: ["internal/crawler/**/*.go", "**/*crawler*.go"]
+alwaysApply: false
 ---
 
 # Web Crawler Implementation Guidelines

--- a/.cursor/rules/deployment.mdc
+++ b/.cursor/rules/deployment.mdc
@@ -1,8 +1,7 @@
 ---
-title: "Deployment and CI/CD Guidelines"
-description: "GitHub Actions, containerization, and release management standards"
-type: "Auto Attached"
-patterns: [".github/**/*.yml", ".github/**/*.yaml", "**/Dockerfile", "**/docker-compose.yml", "**/*release*"]
+description: "Deployment and CI/CD guidelines for GitHub Actions, Docker, and binary distribution"
+globs: [".github/workflows/**/*.yml", "Dockerfile", "**/*deploy*.go"]
+alwaysApply: false
 ---
 
 # Deployment and CI/CD Guidelines

--- a/.cursor/rules/main.mdc
+++ b/.cursor/rules/main.mdc
@@ -1,8 +1,7 @@
 ---
-title: "Crawld Project Main Guidelines"
 description: "Core development guidelines for the crawld Go CLI tool"
-type: "Auto Attached"
-patterns: ["**/*.go", "**/*.md", "**/go.mod", "**/go.sum"]
+globs: ["**/*.go", "**/*.md", "**/go.mod", "**/go.sum"]
+alwaysApply: false
 ---
 
 # Crawld Project Guidelines

--- a/.cursor/rules/project-structure.mdc
+++ b/.cursor/rules/project-structure.mdc
@@ -1,6 +1,12 @@
-# Crawld Project Structure and Coding Conventions
+---
+description: "Project structure and coding conventions for the crawld Go project"
+globs: ["**/*.go", "go.mod", "go.sum"]
+alwaysApply: true
+---
 
-## 📁 Project Structure
+# Project Structure Guidelines
+
+## Directory Structure
 
 ```
 crawld/


### PR DESCRIPTION
## 概要
Cursor Rulesのメタ情報とファイル拡張子を正しいMDCフォーマットに修正しました。

## 変更内容

### 1. ファイル拡張子の修正
- `.md` → `.mdc` (MDC: Metadata Document Content)

### 2. メタ情報フィールドの修正
**変更前（間違ったフォーマット）：**
```yaml
---
title: "..."
description: "..."
type: "Auto Attached"
patterns: ["..."]
---
```

**変更後（正しいMDCフォーマット）：**
```yaml
---
description: "..."
globs: ["..."]
alwaysApply: false
---
```

### 3. 修正されたファイル
- `main.mdc` - コアガイドライン（Auto Attached）
- `cli.mdc` - CLI開発ガイドライン（Auto Attached）  
- `crawler.mdc` - クローラー実装ガイドライン（Auto Attached）
- `deployment.mdc` - デプロイメント・CI/CDガイドライン（Auto Attached）
- `project-structure.mdc` - プロジェクト構造ガイドライン（Always Applied）

## 参考資料
- [Cursor Rules Documentation](https://docs.cursor.com/context/rules)

これで、Cursor RulesはMDCフォーマットの正しい仕様に従って動作するようになります。