### PR TITLE
feat: Update container guidelines to use Go official images

### DIFF
--- a/.cursor/rules/deployment.mdc
+++ b/.cursor/rules/deployment.mdc
@@ -54,25 +54,23 @@ jobs:
 
 ### Multi-stage Dockerfile Structure
 ```dockerfile
-# Build stage - Use Ubuntu/Debian (NOT Alpine)
-FROM ubuntu:22.04 AS builder
+# Build stage - Use Go official image matching go.mod version
+FROM golang:1.24 AS builder
 
-RUN apt-get update && apt-get install -y \
-    ca-certificates \
-    git \
-    golang-go \
-    && rm -rf /var/lib/apt/lists/*
+# Install ca-certificates for HTTPS requests
+RUN apt-get update && apt-get install -y ca-certificates && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app
 COPY go.mod go.sum ./
 RUN go mod download
 
 COPY . .
-RUN CGO_ENABLED=0 GOOS=linux go build -o crawld ./cmd/crawld
+RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o crawld ./cmd/crawld
 
 # Runtime stage - Use distroless
 FROM gcr.io/distroless/static-debian11:nonroot
 
+COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 COPY --from=builder /app/crawld /usr/local/bin/crawld
 
 USER nonroot:nonroot
@@ -80,10 +78,11 @@ ENTRYPOINT ["/usr/local/bin/crawld"]
 ```
 
 ### Container Image Standards
-- **Build images**: Use `ubuntu:22.04` or `debian:bookworm`
+- **Build images**: Use `golang:X.Y` where X.Y matches go.mod version (avoid Alpine variants)
 - **Runtime images**: Use `gcr.io/distroless/static-debian11:nonroot`
-- **Avoid**: Alpine images due to potential compatibility issues
-- Include minimal necessary dependencies only
+- Always match Go version in build image with go.mod specification
+- Use standard Debian-based Go images for better compatibility
+- Include ca-certificates for HTTPS requests
 - Use non-root user for security
 
 ### Docker Registry


### PR DESCRIPTION
## Summary

This PR updates the deployment guidelines to use Go official images instead of Ubuntu/Debian base images for container builds, improving consistency and maintainability.

## Changes

### Container Guidelines Update
- **Build Images**: Changed from `ubuntu:22.04` to `golang:X.Y` matching go.mod version
- **Compatibility**: Use standard Debian-based Go images (avoid Alpine variants)
- **Simplification**: Leverages pre-configured Go environment from official images

### Key Improvements
1. **Version Consistency**: Ensures build image Go version matches go.mod specification (currently 1.24)
2. **Simplified Build Process**: Eliminates manual Go installation steps
3. **Better Compatibility**: Uses standard Debian-based images instead of Alpine
4. **Proper HTTPS Support**: Maintains ca-certificates handling for secure requests
5. **Security**: Continues to use distroless runtime images with non-root user

### Files Modified
- `.cursor/rules/deployment.mdc`: Updated container guidelines and Docker example

## Testing

The updated guidelines provide a more streamlined and consistent approach to containerization that:
- Reduces build complexity
- Ensures Go version consistency between development and deployment
- Maintains security best practices
- Improves maintainability

## Type of Change
- [x] Documentation update
- [x] Build/deployment improvement
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change

## Checklist
- [x] Guidelines updated to use Go official images
- [x] Documentation reflects current go.mod version (1.24)
- [x] Maintains security best practices (distroless, non-root)
- [x] Avoids Alpine variants for better compatibility