### PR TITLE
feat: Enable Playwright tests in CI environment - Phase 1 (Basic Setup)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,12 @@ jobs:
       - name: Build
         run: go build -v ./...
 
+      - name: Install Playwright CLI
+        run: go install github.com/playwright-community/playwright-go/cmd/playwright@latest
+
+      - name: Install Playwright browsers
+        run: playwright install --with-deps chromium
+
       - name: Run tests
         run: go test -v -race -coverprofile=coverage.out ./...
 


### PR DESCRIPTION
## Summary
- Add Playwright dependency installation to CI workflow
- Install Chromium browser with system dependencies for testing
- Enable browser-based tests to run in GitHub Actions

## Background
Currently, Playwright tests are skipped in CI environment due to missing system dependencies. This PR implements Phase 1 of enabling Playwright tests in CI by installing the necessary dependencies.

## Changes
1. Added `Install Playwright CLI` step to install the playwright-go command-line tool
2. Added `Install Playwright browsers` step to install Chromium with system dependencies using `playwright install --with-deps chromium`
3. These steps are placed before the test execution to ensure Playwright is available

## Technical Details
- Uses official Playwright CLI for Go: `github.com/playwright-community/playwright-go/cmd/playwright`
- Installs only Chromium browser to minimize CI time and disk usage
- The `--with-deps` flag ensures all required system libraries are installed

## Testing
- The existing `TestBrowserPool_RenderPage` test will validate the setup
- CI should now successfully run browser-based tests without skipping them

## Related Issues
- Closes #62
- This is Phase 1 of 3 for enabling Playwright in CI
- Phase 2 will implement browser binary caching
- Phase 3 will enable all Playwright tests

🤖 Generated with [Claude Code](https://claude.ai/code)